### PR TITLE
Update 2024-10-26-howtodev-mermaidjs-pt3.md

### DIFF
--- a/_posts/2024-10-26-howtodev-mermaidjs-pt3.md
+++ b/_posts/2024-10-26-howtodev-mermaidjs-pt3.md
@@ -24,7 +24,7 @@ Utilizzo dei Class diagrams.
 
 L'articolo affronterà i seguenti argomenti:
 
-- Class diagrams su mermaid JS
+- Class diagrams su MermaidJS
 
 ## Prerequisiti
 


### PR DESCRIPTION
"mermaid JS" dovrebbe essere "MermaidJS" per coerenza con l'uso precedente.